### PR TITLE
Added Opinionated Guides

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -92,5 +92,6 @@ const sites = [
   { url: 'https://kor.nz', title: 'kor', type: 'wiki', author: 'kormyen', contact: 'h@kor.nz', feed: 'https://kor.nz/twtxt.txt', wiki: 'https://kor.nz/db/glossary.ndtl' },
   { url: 'https://lublin.se', author: 'quite', contact: 'quite@hack.org', feed: 'https://lublin.se/twtxt.txt' },
   { url: 'https://zanneth.com', title: 'zanneth.com', author: 'zanneth', type: 'blog', contact: 'root@zanneth.com' },
-  { url: 'https://eli.li', title: 'eli.li', author: 'eli_oat', type: 'blog', contact: 'hi@eli.li', rss: 'https://eli.li/feed.rss', feed: 'https://txt.eli.li/twtxt/twtxt.txt' }
+  { url: 'https://eli.li', title: 'eli.li', author: 'eli_oat', type: 'blog', contact: 'hi@eli.li', rss: 'https://eli.li/feed.rss', feed: 'https://txt.eli.li/twtxt/twtxt.txt' },
+  { url: 'https://opinionatedguide.github.io/', title: 'OpGuides', contact: 'vegac@protonmail.com', feed: 'https://opinionatedguide.github.io/twtxt.txt' }
 ]


### PR DESCRIPTION
Webring icon prominently displayed in the bottom left side of every page, in the footer.

The site is for hosting information for learning computer and electrical engineering, but may wind up containing multiple blog type posts from contributors in the future. Right now the site contains 3 pages of actual content, OpinionatedMusic, OpinionatedEngineering, and OpinionatedDesign. Of these, OpDesign is pracically empty at the moment while OpEng is already massive and OpMusic is growing rapidly.

Repo availabe at https://github.com/opinionatedguide/opinionatedguide.github.io-src . Just recently moved everything over to that repo and had to murder commit history in the process.